### PR TITLE
Fix turnover export

### DIFF
--- a/lists/utils/export_excel.py
+++ b/lists/utils/export_excel.py
@@ -45,7 +45,7 @@ def generate_companies_excel(companies, listname):
             company.website,
             company.legalform,
             keyfigures.get('equity', ''),
-            keyfigures.get('revenue', ''),
+            keyfigures.get('turnover', ''),
             keyfigures.get('margin', ''),
             keyfigures.get('ebitda', ''),
             keyfigures.get('profit', ''),


### PR DESCRIPTION
## Summary
- use `turnover` key when exporting companies to Excel

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6841d5ee2200833187e8948e3a81e052