### PR TITLE
Fix remuneration key in excel export

### DIFF
--- a/lists/utils/export_excel.py
+++ b/lists/utils/export_excel.py
@@ -51,7 +51,7 @@ def generate_companies_excel(companies, listname):
             keyfigures.get('profit', ''),
             keyfigures.get('net_debt', ''),
             keyfigures.get('capex', ''),
-            keyfigures.get('remunerations', ''),
+            keyfigures.get('remuneration', ''),
             keyfigures.get('fte', ''),
             keyfigures.get('real_estate', '')
         ]


### PR DESCRIPTION
## Summary
- correct the remuneration key when exporting company rows to Excel

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6841d617c13c83318794c5720645d9bf